### PR TITLE
Ajuste em ProtocolGame:sendSaleItemList

### DIFF
--- a/src/protocolgame.cpp
+++ b/src/protocolgame.cpp
@@ -1351,15 +1351,16 @@ void ProtocolGame::sendSaleItemList(const std::list<ShopInfo>& shop)
 	msg.addByte(0x7B);
 
 	uint16_t moneyType = player->shopOwner ? player->shopOwner->getMoneyType() : 0;
-
-	if (g_config.getBoolean(ConfigManager::NPCS_USING_BANK_MONEY)) {
-		msg.add<uint32_t>(player->getMoney() + player->getBankBalance());
-	} else {
-		if (moneyType == 0) {
-			msg.add<uint32_t>(player->getMoney());
+	if (moneyType == 0) {
+		uint64_t playerMoney = player->getMoney();
+		if (g_config.getBoolean(ConfigManager::NPCS_USING_BANK_MONEY)) {
+			uint64_t playerBank = player->getBankBalance();
+			msg.add<uint64_t>(playerBank + playerMoney); // deprecated and ignored by QT client. OTClient still uses it.
 		} else {
-			msg.add<uint32_t>(player->getItemTypeCount(moneyType));
+			msg.add<uint64_t>(playerBank);
 		}
+	} else {
+		msg.add<uint32_t>(player->getItemTypeCount(moneyType));
 	}
 
 	std::map<uint16_t, uint32_t> saleMap;

--- a/src/protocolgame.cpp
+++ b/src/protocolgame.cpp
@@ -1357,7 +1357,7 @@ void ProtocolGame::sendSaleItemList(const std::list<ShopInfo>& shop)
 			uint64_t playerBank = player->getBankBalance();
 			msg.add<uint64_t>(playerBank + playerMoney); // deprecated and ignored by QT client. OTClient still uses it.
 		} else {
-			msg.add<uint64_t>(playerBank);
+			msg.add<uint64_t>(playerMoney);
 		}
 	} else {
 		msg.add<uint32_t>(player->getItemTypeCount(moneyType));


### PR DESCRIPTION
Creio que a função ficaria correta desta forma, tendo em vista que esse o usuário deixar "verdadeiro" para NPCS_USING_BANK_MONEY ele não consegue usar o sistema dos npcs usarem outros tipos de pagamento a não ser DINHEIRO.