### PR TITLE
Ajuste na condição BLOCK_LOGIN no login

### DIFF
--- a/src/protocollogin.cpp
+++ b/src/protocollogin.cpp
@@ -137,8 +137,8 @@ void ProtocolLogin::onRecvFirstMessage(NetworkMessage& msg)
 		return;
 	}
 
-	const std::string customMessage = g_config.getString(ConfigManager::BLOCK_LOGIN_TEXT);
 	if (g_config.getBoolean(ConfigManager::BLOCK_LOGIN)) {
+		const std::string customMessage = g_config.getString(ConfigManager::BLOCK_LOGIN_TEXT);
 		disconnectClient(customMessage);
 		return;
 	}


### PR DESCRIPTION
A constante **customMessage** não precisa ser carregada se o valor de **BLOCK_LOGIN** for falso.